### PR TITLE
Fix Memory Issues?

### DIFF
--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -329,7 +329,7 @@ int AcceptAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_s
   char rep_buf[BUF_LENGTH_SMALL];
   FlashStrPtr json_skeleton = F("{\""BUZZER_NAME_FIELD"\":\"%s\",\""PARTY_ID_FIELD"\":%d}");
   // calculate the number of digits in the current party_id
-  int num_digits = floor(log10(abs(party_id))) + 1;
+  int num_digits = NUM_DIGITS(party_id);
   // -4 is because the string format specifiers won't actually be in the final char buf.
   char post_data[strlen_P((prog_char *)json_skeleton)+strlen(buzzer_name_global)+num_digits+1];
   snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, buzzer_name_global, party_id);

--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -105,13 +105,13 @@ int InitGPRSFunc(unsigned long state_start_time, int num_iterations_in_state) {
 int GetBuzzerNameFunc(unsigned long state_start_time, int num_iterations_in_state) {
   oled.clear();
   OLED_PRINTLN_FLASH("Getting a name.....");
-  char buf[_max_line_length];
+  char buf[BUF_LENGTH_MEDIUM];
   fona_shield.HTTPGETOneLine(F("http://restaur-anteater.herokuapp.com/buzzer_api/get_new_buzzer_name"), buf, sizeof(buf));
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_MEDIUM> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(buf);
   //TODO: better error handling here
-  const char *error = root["error"];
-  const char *buzzer_name = root["buzzer_name"];
+  short error = root[ERROR_STATUS_FIELD];
+  const char *buzzer_name = root[BUZZER_NAME_FIELD];
   Serial.println(buzzer_name);
   EEPROMWrite(buzzer_name, strlen(buzzer_name)+1);
   strncpy(buzzer_name_global, buzzer_name, sizeof(buzzer_name_global));
@@ -243,12 +243,12 @@ int SleepFunc(unsigned long state_start_time, int num_iterations_in_state) {
 */
 
 bool IsBuzzerRegistered() {
-  char rep_buf[_max_line_length];
+  char rep_buf[BUF_LENGTH_SMALL];
  //TODO: better error handling
   APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/is_buzzer_registered"), rep_buf, sizeof(rep_buf), false);
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_SMALL> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
-  bool is_buzzer_registered = root["is_buzzer_registered"];
+  short is_buzzer_registered = root[IS_BUZZER_REGISTERED_FIELD];
   return is_buzzer_registered;
 }
 
@@ -264,10 +264,11 @@ bool IsBuzzerRegistered() {
 */
 
 int APIPOSTBuzzerName(FlashStrPtr api_endpoint, char *rep_buf, int rep_buf_len, bool is_buzzing) {
-  FlashStrPtr json_skeleton = F("{\"buzzer_name\":\"\",\"buzzing\": 0}");
-  char post_data[strlen_P((prog_char *)json_skeleton)+strlen(buzzer_name_global)+1];
+  FlashStrPtr json_skeleton = F("{\""BUZZER_NAME_FIELD"\":\"%s\"}");
+  // -2 because the string format specificer won't be in the char buf after the snprintf.
+  char post_data[strlen_P((prog_char *)json_skeleton)-2+strlen(buzzer_name_global)+1];
   Serial.println(strlen_P((prog_char *)json_skeleton));
-  snprintf(post_data, sizeof(post_data), "{\"buzzer_name\":\"%s\",\"buzzing\": %d}", buzzer_name_global, is_buzzing);
+  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, buzzer_name_global);
   return fona_shield.HTTPPOSTOneLine(api_endpoint, post_data, sizeof(post_data), rep_buf, rep_buf_len);
 }
 
@@ -292,25 +293,26 @@ int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
     int num_digits_hrs = wait_time_hrs < 10 ? NUM_DIGITS(wait_time_hrs) + 1 : NUM_DIGITS(wait_time_hrs);
     int num_digits_min = wait_time_min < 10 ? NUM_DIGITS(wait_time_min) + 1 : NUM_DIGITS(wait_time_min);
     char buf[num_digits_min + num_digits_hrs + 4];
-    snprintf(buf, sizeof(buf), "%02dh:%02dm", wait_time_hrs, wait_time_min);
+    snprintf_P(buf, sizeof(buf), (prog_char *)F("%02dh:%02dm"), wait_time_hrs, wait_time_min);
     oled.println(buf);
   }
   UpdateBatteryPercentage(4, num_iterations_in_state);
   PrintFreeRAM();
-  char rep_buf[_max_line_length];
+  char rep_buf[BUF_LENGTH_MEDIUM];
  //TODO: better error handling
   PrintFreeRAM();
   APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/heartbeat"), rep_buf, sizeof(rep_buf), false);
   PrintFreeRAM();
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_MEDIUM> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
   PrintFreeRAM();
-  if (strcmp(root["status"], "success") != 0) return REPEAT;
-  bool is_active = root["is_active"];
+  short err = root[ERROR_STATUS_FIELD];
+  if (err) return REPEAT;
+  short is_active = root[IS_ACTIVE_FIELD];
   if (!is_active) return TIMEOUT;
-  bool buzz = root["buzz"];
+  short buzz = root[BUZZ_FIELD];
   if (buzz) return SUCCESS;
-  wait_time = root["wait_time"];
+  wait_time = root[PARTY_WAIT_TIME_FIELD];
   return REPEAT;
 }
 
@@ -324,16 +326,18 @@ int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
 */
 
 int AcceptAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_state) {
-  char rep_buf[_max_line_length];
-  FlashStrPtr json_skeleton = F("{\"buzzer_name\":\"\",\"party_id\":\"\"}");
-  //calculate the number of digits in the current party_id
+  char rep_buf[BUF_LENGTH_SMALL];
+  FlashStrPtr json_skeleton = F("{\""BUZZER_NAME_FIELD"\":\"%s\",\""PARTY_ID_FIELD"\":%d}");
+  // calculate the number of digits in the current party_id
   int num_digits = floor(log10(abs(party_id))) + 1;
+  // -4 is because the string format specifiers won't actually be in the final char buf.
   char post_data[strlen_P((prog_char *)json_skeleton)+strlen(buzzer_name_global)+num_digits+1];
-  snprintf(post_data, sizeof(post_data), "{\"buzzer_name\":\"%s\",\"party_id\":\"%d\"}", buzzer_name_global, party_id);
+  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, buzzer_name_global, party_id);
   fona_shield.HTTPPOSTOneLine(F("http://restaur-anteater.herokuapp.com/buzzer_api/accept_party"), post_data, sizeof(post_data), rep_buf, sizeof(rep_buf));
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_SMALL> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
-  if (strcmp(root["status"], "success") == 0) return SUCCESS;
+  short err = root[ERROR_STATUS_FIELD];
+  if (!err) return SUCCESS;
   return ERROR;
 }
 
@@ -353,15 +357,15 @@ int GetAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_stat
   OLED_PRINTLN_FLASH("Checking for parties");
   OLED_PRINTLN_FLASH("with no buzzer");
   delay(100);
-  char rep_buf[_max_line_length];
+  char rep_buf[BUF_LENGTH_LARGE];
   APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/get_available_party"), rep_buf, sizeof(rep_buf), false);
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_LARGE> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
-  bool party_avail = root["party_avail"];
+  bool party_avail = root[PARTY_AVAIL_FIELD];
   if (party_avail){
-    wait_time = root["wait_time"];
-    party_id = root["party_id"];
-    strncpy(party_name, root["party_name"], sizeof(party_name)-1);
+    wait_time = root[PARTY_WAIT_TIME_FIELD];
+    party_id = root[PARTY_ID_FIELD];
+    strncpy(party_name, root[PARTY_NAME_FIELD], sizeof(party_name)-1);
     party_name[sizeof(party_name)-1] = '\0';
     return SUCCESS;
   }
@@ -441,12 +445,12 @@ int BuzzFunc(unsigned long state_start_time, int num_iterations_in_state) {
   analogWrite(BUZZER_PIN, 255);
   delay(2000);
   analogWrite(BUZZER_PIN, 0);
-  char rep_buf[_max_line_length];
+  char rep_buf[BUF_LENGTH_MEDIUM];
  //TODO: better error handling
   APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/heartbeat"), rep_buf, sizeof(rep_buf), true);
-  StaticJsonBuffer<_max_line_length> jsonBuffer;
+  StaticJsonBuffer<BUF_LENGTH_MEDIUM> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
-  bool is_active = root["is_active"];
+  short is_active = root[IS_ACTIVE_FIELD];
   if (!is_active) return SUCCESS;
   return REPEAT;
 }

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -13,6 +13,16 @@
 #include "Helpers.h"
 #include "Pins.h"
 
+#define PARTY_AVAIL_FIELD "p_a"
+#define PARTY_NAME_FIELD "n"
+#define PARTY_WAIT_TIME_FIELD "t"
+#define PARTY_ID_FIELD "id"
+#define BUZZER_NAME_FIELD "bn"
+#define IS_ACTIVE_FIELD "i_a"
+#define BUZZ_FIELD "b"
+#define IS_BUZZER_REGISTERED_FIELD "i_reg"
+#define ERROR_STATUS_FIELD "e"
+#define ERROR_MESSAGE_FIELD "e_msg"
 
 int InitFunc(unsigned long state_start_time, int num_iterations_in_state);
 int BuzzFunc(unsigned long state_start_time, int num_iterations_in_state);

--- a/buzzer/FonaShield.cpp
+++ b/buzzer/FonaShield.cpp
@@ -90,7 +90,7 @@ bool FonaShield::enableGPRS() {
 */
 
 int FonaShield::GetBatteryVoltage() {
-  char batt_stat_res_buf[30];
+  char batt_stat_res_buf[BUF_LENGTH_SMALL];
   sendATCommand(F("AT+CBC"));
   if (!readAvailBytesFromSerial(batt_stat_res_buf, sizeof(batt_stat_res_buf), 500)) return -1;
   if (batt_stat_res_buf == NULL) return -1;
@@ -116,7 +116,7 @@ int FonaShield::GetBatteryVoltage() {
 */
 
 int FonaShield::GetOneLineHTTPRes(char *http_res_buffer, int http_res_buffer_len) {
-  char at_res_buffer[_max_line_length];
+  char at_res_buffer[BUF_LENGTH_LARGE];
   unsigned long start_time = millis();
   while(sendATCommandCheckReply(F("AT+HTTPREAD"), at_res_buffer, sizeof(at_res_buffer), OK_REPLY, 1000)) {
     // Deals with millis() overflowing
@@ -163,7 +163,7 @@ int FonaShield::HTTPPOSTOneLine(FlashStrPtr URL, char *post_data_buffer, int pos
 */
 
 bool FonaShield::sendHTTPDataCheckReply(char *post_data_buffer, int post_data_buffer_len) {
-  char buf[_max_line_length];
+  char buf[BUF_LENGTH_LARGE];
   // the 1000 represents how long in ms the cell radio will wait for more bytes of the POST data
   // before moving on.
   sprintf_P(buf, (prog_char *)F("AT+HTTPDATA=%d,1000"), post_data_buffer_len);
@@ -354,7 +354,7 @@ bool FonaShield::sendATCommandParamCheckReply(FlashStrPtr at_command, FlashStrPt
 
 bool FonaShield::sendATCommandCheckAck(FlashStrPtr command, unsigned long timeout) {
   sendATCommand(command);
-  char rep_buffer[_max_line_length];
+  char rep_buffer[BUF_LENGTH_LARGE];
   return readAvailBytesFromSerial(rep_buffer, sizeof(rep_buffer), timeout);
 }
 
@@ -372,7 +372,7 @@ bool FonaShield::sendATCommandCheckAck(FlashStrPtr command, unsigned long timeou
 */
 
 bool FonaShield::checkATCommandReply(FlashStrPtr expected_reply, unsigned long timeout) {
-  char rep_buffer[_max_line_length];
+  char rep_buffer[BUF_LENGTH_LARGE];
   readAvailBytesFromSerial(rep_buffer, sizeof(rep_buffer), timeout);
   return isEqual(rep_buffer, expected_reply);
 }

--- a/buzzer/FonaShield.cpp
+++ b/buzzer/FonaShield.cpp
@@ -163,10 +163,13 @@ int FonaShield::HTTPPOSTOneLine(FlashStrPtr URL, char *post_data_buffer, int pos
 */
 
 bool FonaShield::sendHTTPDataCheckReply(char *post_data_buffer, int post_data_buffer_len) {
-  char buf[BUF_LENGTH_LARGE];
   // the 1000 represents how long in ms the cell radio will wait for more bytes of the POST data
   // before moving on.
-  sprintf_P(buf, (prog_char *)F("AT+HTTPDATA=%d,1000"), post_data_buffer_len);
+  FlashStrPtr command_skeleton = F("AT+HTTPDATA=%d,1000");
+  int num_digits_post_data_buf_len = NUM_DIGITS(post_data_buffer_len);
+  // -2 because the format specifier won't who up in the actual buf
+  char buf[strlen_P((prog_char *)command_skeleton)-2+num_digits_post_data_buf_len+1];
+  snprintf_P(buf, sizeof(buf), (prog_char *)command_skeleton, post_data_buffer_len);
   DEBUG_PRINT_FLASH("Sent: ");
   DEBUG_PRINTLN(buf);
   _fona_serial->println(buf);
@@ -354,7 +357,7 @@ bool FonaShield::sendATCommandParamCheckReply(FlashStrPtr at_command, FlashStrPt
 
 bool FonaShield::sendATCommandCheckAck(FlashStrPtr command, unsigned long timeout) {
   sendATCommand(command);
-  char rep_buffer[BUF_LENGTH_LARGE];
+  char rep_buffer[BUF_LENGTH_SMALL];
   return readAvailBytesFromSerial(rep_buffer, sizeof(rep_buffer), timeout);
 }
 
@@ -372,7 +375,7 @@ bool FonaShield::sendATCommandCheckAck(FlashStrPtr command, unsigned long timeou
 */
 
 bool FonaShield::checkATCommandReply(FlashStrPtr expected_reply, unsigned long timeout) {
-  char rep_buffer[BUF_LENGTH_LARGE];
+  char rep_buffer[BUF_LENGTH_MEDIUM];
   readAvailBytesFromSerial(rep_buffer, sizeof(rep_buffer), timeout);
   return isEqual(rep_buffer, expected_reply);
 }

--- a/buzzer/Globals.h
+++ b/buzzer/Globals.h
@@ -20,18 +20,21 @@ extern SoftwareSerial fona_serial;
 extern FonaShield fona_shield;
 extern SSD1306AsciiAvrI2c oled;
 enum ret_vals {SUCCESS, ERROR, REPEAT, TIMEOUT};
-//longest length of buzzer name should be around this
+// longest length of buzzer name should be around this
 extern char buzzer_name_global[30];
 extern int party_id;
-extern int wait_time;
-extern char party_name[30];
-extern int batt_percentage;
+extern short wait_time;
+// party names received from the API calls are truncated at 20 characters.
+extern char party_name[20];
+extern short batt_percentage;
 extern bool has_system_been_initialized;
 extern unsigned long button_press_start;
 extern bool usb_cabled_plugged_in;
 
 #define MAX_RETRIES 10
-#define _max_line_length 120
+#define BUF_LENGTH_LARGE 90
+#define BUF_LENGTH_MEDIUM 64
+#define BUF_LENGTH_SMALL 32
 #define NO_PARTY -1
 
 #endif

--- a/buzzer/Helpers.h
+++ b/buzzer/Helpers.h
@@ -22,6 +22,8 @@
 #define OLED_PRINTLN_FLASH(str) oled.println(F(str))
 #define OLED_PRINT_FLASH(str) oled.print(F(str))
 
+#define NUM_DIGITS(num) floor(log10(abs(num))) + 1
+
 #define NUM_DIGITS(x) ((x == 0) ? 1 : floor(log10(abs(x))) + 1)
 
 typedef char PROGMEM prog_char;

--- a/buzzer/buzzer.ino
+++ b/buzzer/buzzer.ino
@@ -157,14 +157,14 @@ void loop() {
   }
 
   // Poke the FSM if the the USB cable has been plugged in or unplugged.
-  // if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = true;
-  //   buzzer_fsm.USBCablePluggedIn();
-  // }
-  // if (readVcc() < 4300 && usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = false;
-  //   buzzer_fsm.USBCableUnplugged();
-  // }
+  if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = true;
+    buzzer_fsm.USBCablePluggedIn();
+  }
+  if (readVcc() < 4300 && usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = false;
+    buzzer_fsm.USBCableUnplugged();
+  }
 
   // Record the start time of a button press.
   if (digitalRead(BUTTON_PIN) == HIGH && button_press_start == 0) button_press_start = millis();

--- a/buzzer/buzzer.ino
+++ b/buzzer/buzzer.ino
@@ -23,9 +23,9 @@ FonaShield fona_shield(&fona_serial, FONA_RST_PIN);
 SSD1306AsciiAvrI2c oled;
 char buzzer_name_global[30];
 int party_id = NO_PARTY;
-int wait_time = NO_PARTY;
-char party_name[30];
-int batt_percentage = 100;
+short wait_time = NO_PARTY;
+char party_name[20];
+short batt_percentage = 100;
 bool has_system_been_initialized = false;
 unsigned long button_press_start = 0;
 unsigned long last_batt_update = 0;
@@ -157,14 +157,14 @@ void loop() {
   }
 
   // Poke the FSM if the the USB cable has been plugged in or unplugged.
-  if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
-    usb_cabled_plugged_in = true;
-    buzzer_fsm.USBCablePluggedIn();
-  }
-  if (readVcc() < 4300 && usb_cabled_plugged_in) {
-    usb_cabled_plugged_in = false;
-    buzzer_fsm.USBCableUnplugged();
-  }
+  // if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
+  //   usb_cabled_plugged_in = true;
+  //   buzzer_fsm.USBCablePluggedIn();
+  // }
+  // if (readVcc() < 4300 && usb_cabled_plugged_in) {
+  //   usb_cabled_plugged_in = false;
+  //   buzzer_fsm.USBCableUnplugged();
+  // }
 
   // Record the start time of a button press.
   if (digitalRead(BUTTON_PIN) == HIGH && button_press_start == 0) button_press_start = millis();


### PR DESCRIPTION
This PR attempts to reduce the amount of stack used by the Buzzer.

API field name length was greatly reduced which allowed for smaller buffers. There are now three sizes of buffers, `BUF_LENGTH_LARGE` (90 bytes), `BUF_LENGTH_MEDIUM` (64 bytes), and `BUF_LENGTH_SMALL` (32 bytes). The jumbo sized buffer is only used in one place (`GetAvailPartyFunc`) because of the party name. 

Party names are going to be capped at 20 characters.

Also reduced the sizing of some of the internal stack char bufs used by FonaSerial.

Plausibly fixes https://github.com/jfeiber/buzzer-embedded/issues/18 but more testing is required to make sure I wasn't too aggressive with the buffer length downsizing. 