### PR TITLE
Better Error Handling

### DIFF
--- a/buzzer/BuzzerFSM.h
+++ b/buzzer/BuzzerFSM.h
@@ -26,7 +26,7 @@ struct State {
 // enum that contains all the possible state IDs.
 enum state_ids {INIT, INIT_FONA, INIT_GPRS, GET_BUZZER_NAME, IDLE, CHECK_BUZZER_REGISTRATION,
                 WAIT_BUZZER_REGISTRATION, GET_AVAILABLE_PARTY, ACCEPT_AVAILABLE_PARTY, HEARTBEAT,
-                BUZZ, CHARGING, SHUTDOWN, SLEEP, WAKEUP};
+                BUZZ, CHARGING, SHUTDOWN, SLEEP, FATAL_ERROR, WAKEUP};
 
 // _state_start_time is set to this after a state has been
 // transitioned to. This is not a private class variable to save space.

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -32,7 +32,7 @@ int GetBuzzerNameFunc(unsigned long state_start_time, int num_iterations_in_stat
 int IdleFunc(unsigned long state_start_time, int num_iterations_in_state);
 int CheckBuzzerRegFunc(unsigned long state_start_time, int num_iterations_in_state);
 int WaitBuzzerRegFunc(unsigned long state_start_time, int num_iterations_in_state);
-static bool IsBuzzerRegistered();
+static int IsBuzzerRegistered(bool *is_buzzer_registered);
 int GetAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_state);
 static int APIPOSTBuzzerName(FlashStrPtr api_endpoint, char *rep_buf, int rep_buf_len, bool is_buzzing);
 int AcceptAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_state);
@@ -41,6 +41,7 @@ int ShutdownFunc(unsigned long state_start_time, int num_iterations_in_state);
 int SleepFunc(unsigned long state_start_time, int num_iterations_in_state);
 int WakeupFunc(unsigned long state_start_time, int num_iterations_in_state);
 int ChargeFunc(unsigned long state_start_time, int num_iterations_in_state);
+int FatalErrorFunc(unsigned long state_start_time, int num_iterations_in_state);
 static void UpdateBatteryPercentage(int row, int num_iterations_in_state);
 
 #endif


### PR DESCRIPTION
Introduces a fatal error state for when an API call fails more than MAX_RETRIES number of times.

This state will display a message, vibrate the buzzer twice, wait 10 seconds, then go back to INIT and start over. Once the Buzzer is able to recover from crashes, it should go back to the HEARTBEAT state if it was previously connected to an active party.

Fixes https://github.com/jfeiber/buzzer-embedded/issues/15 and a bunch of longstanding todos. 