### PR TITLE
Buzzer Crash Recovery

### DIFF
--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -271,6 +271,10 @@ int APIPOSTBuzzerName(FlashStrPtr api_endpoint, char *rep_buf, int rep_buf_len, 
   return fona_shield.HTTPPOSTOneLine(api_endpoint, post_data, sizeof(post_data), rep_buf, rep_buf_len);
 }
 
+/*
+ * Helper method that sets the curr_party_id to NO_PARTY and updates the data stored in the EEPROM.
+*/
+
 void SetEEPROMDataNoParty() {
   eeprom_data.curr_party_id = NO_PARTY;
   EEPROMWrite(&eeprom_data);
@@ -326,7 +330,6 @@ int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
   }
   short buzz = root[BUZZ_FIELD];
   if (buzz) return SUCCESS;
-  // wait_time = root[PARTY_WAIT_TIME_FIELD];
   return REPEAT;
 }
 
@@ -385,7 +388,6 @@ int GetAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_stat
     eeprom_data.wait_time = root[PARTY_WAIT_TIME_FIELD];
     eeprom_data.curr_party_id = root[PARTY_ID_FIELD];
     strncpy(eeprom_data.party_name, root[PARTY_NAME_FIELD], sizeof(eeprom_data.party_name));
-    // eeprom_data.party_name[sizeof(eeprparty_name)-1] = '\0';
     return SUCCESS;
   }
   oled.clear();

--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -123,6 +123,7 @@ int GetBuzzerNameFunc(unsigned long state_start_time, int num_iterations_in_stat
  *
  * @input the OLED row the battery percentage should be displayed on.
  * @input how many iterations the FSM has been in the current state.
+ * @input the frequency that the battery info should be written.
 */
 
 void UpdateBatteryPercentage(int row, int num_iterations_in_state, int update_frequency) {
@@ -292,6 +293,8 @@ void SetEEPROMDataNoParty() {
 */
 
 int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
+  // If there is valid party data in the EEPROM the Buzzer will jump to this state, so we want to
+  // check that the party is still actually active before writing all the data to the OLED.
   if (num_iterations_in_state == 1) {
     oled.clear();
     OLED_PRINTLN_FLASH("Party name:");
@@ -304,6 +307,7 @@ int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
     char buf[num_digits_min + num_digits_hrs + 4];
     snprintf_P(buf, sizeof(buf), (prog_char *)F("%02dh:%02dm"), wait_time_hrs, wait_time_min);
     oled.println(buf);
+    // Writes the battery percentage now.
     UpdateBatteryPercentage(4, num_iterations_in_state, 1);
   }
   if (num_iterations_in_state != 0) UpdateBatteryPercentage(4, num_iterations_in_state, 5);

--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -111,8 +111,8 @@ int GetBuzzerNameFunc(unsigned long state_start_time, int num_iterations_in_stat
   if (root[ERROR_STATUS_FIELD]) return (num_iterations_in_state < MAX_RETRIES) ? REPEAT : ERROR;
   const char *buzzer_name = root[BUZZER_NAME_FIELD];
   Serial.println(buzzer_name);
-  EEPROMWrite(buzzer_name, strlen(buzzer_name)+1);
-  strncpy(buzzer_name_global, buzzer_name, sizeof(buzzer_name_global));
+  strncpy(eeprom_data.buzzer_name, buzzer_name, sizeof(eeprom_data.buzzer_name));
+  EEPROMWrite(&eeprom_data);
   return SUCCESS;
 }
 
@@ -125,8 +125,8 @@ int GetBuzzerNameFunc(unsigned long state_start_time, int num_iterations_in_stat
  * @input how many iterations the FSM has been in the current state.
 */
 
-void UpdateBatteryPercentage(int row, int num_iterations_in_state) {
-  if (num_iterations_in_state % 1000 == 0) {
+void UpdateBatteryPercentage(int row, int num_iterations_in_state, int update_frequency) {
+  if (num_iterations_in_state % update_frequency == 0) {
     oled.setCol(0);
     oled.setRow(row);
     oled.clearToEOL();
@@ -152,9 +152,9 @@ int IdleFunc(unsigned long state_start_time, int num_iterations_in_state) {
   if (num_iterations_in_state == 0) {
     oled.clear();
     OLED_PRINTLN_FLASH("Buzzer name:");
-    oled.println(buzzer_name_global);
+    oled.println(eeprom_data.buzzer_name);
   }
-  UpdateBatteryPercentage(2, num_iterations_in_state);
+  UpdateBatteryPercentage(2, num_iterations_in_state, 1000);
   if (millis() - state_start_time >= 20000) oled.setContrast(0);
   return REPEAT;
 }
@@ -191,7 +191,7 @@ int ChargeFunc(unsigned long state_start_time, int num_iterations_in_state) {
     oled.clear();
     OLED_PRINTLN_FLASH("Charging.....");
   }
-  UpdateBatteryPercentage(1, num_iterations_in_state);
+  UpdateBatteryPercentage(1, num_iterations_in_state, 1000);
   return REPEAT;
 }
 
@@ -245,8 +245,6 @@ int SleepFunc(unsigned long state_start_time, int num_iterations_in_state) {
 int IsBuzzerRegistered(bool *is_buzzer_registered) {
   char rep_buf[BUF_LENGTH_SMALL];
   int err = APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/is_buzzer_registered"), rep_buf, sizeof(rep_buf), false);
-  Serial.println("API POST:");
-  Serial.println(err);
   if (err == ERROR) return ERROR;
   StaticJsonBuffer<BUF_LENGTH_SMALL> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
@@ -268,10 +266,14 @@ int IsBuzzerRegistered(bool *is_buzzer_registered) {
 int APIPOSTBuzzerName(FlashStrPtr api_endpoint, char *rep_buf, int rep_buf_len, bool is_buzzing) {
   FlashStrPtr json_skeleton = F("{\""BUZZER_NAME_FIELD"\":\"%s\"}");
   // -2 because the string format specificer won't be in the char buf after the snprintf.
-  char post_data[strlen_P((prog_char *)json_skeleton)-2+strlen(buzzer_name_global)+1];
-  Serial.println(strlen_P((prog_char *)json_skeleton));
-  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, buzzer_name_global);
+  char post_data[strlen_P((prog_char *)json_skeleton)-2+strlen(eeprom_data.buzzer_name)+1];
+  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, eeprom_data.buzzer_name);
   return fona_shield.HTTPPOSTOneLine(api_endpoint, post_data, sizeof(post_data), rep_buf, rep_buf_len);
+}
+
+void SetEEPROMDataNoParty() {
+  eeprom_data.curr_party_id = NO_PARTY;
+  EEPROMWrite(&eeprom_data);
 }
 
 /*
@@ -286,26 +288,31 @@ int APIPOSTBuzzerName(FlashStrPtr api_endpoint, char *rep_buf, int rep_buf_len, 
 */
 
 int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
-  if (num_iterations_in_state == 0) {
+  if (num_iterations_in_state == 1) {
     oled.clear();
     OLED_PRINTLN_FLASH("Party name:");
-    oled.println(party_name);
+    oled.println(eeprom_data.party_name);
     OLED_PRINTLN_FLASH("Expected wait time: ");
-    int wait_time_hrs = wait_time/60;
-    int wait_time_min = wait_time - wait_time_hrs*60;
+    int wait_time_hrs = eeprom_data.wait_time/60;
+    int wait_time_min = eeprom_data.wait_time - wait_time_hrs*60;
     int num_digits_hrs = wait_time_hrs < 10 ? NUM_DIGITS(wait_time_hrs) + 1 : NUM_DIGITS(wait_time_hrs);
     int num_digits_min = wait_time_min < 10 ? NUM_DIGITS(wait_time_min) + 1 : NUM_DIGITS(wait_time_min);
     char buf[num_digits_min + num_digits_hrs + 4];
     snprintf_P(buf, sizeof(buf), (prog_char *)F("%02dh:%02dm"), wait_time_hrs, wait_time_min);
     oled.println(buf);
+    UpdateBatteryPercentage(4, num_iterations_in_state, 1);
   }
-  UpdateBatteryPercentage(4, num_iterations_in_state);
+  if (num_iterations_in_state != 0) UpdateBatteryPercentage(4, num_iterations_in_state, 5);
   PrintFreeRAM();
   char rep_buf[BUF_LENGTH_MEDIUM];
   PrintFreeRAM();
-  short err;
-  err = APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/heartbeat"), rep_buf, sizeof(rep_buf), false);
-  if (err) return ERROR;
+  short err = APIPOSTBuzzerName(F("http://restaur-anteater.herokuapp.com/buzzer_api/heartbeat"), rep_buf, sizeof(rep_buf), false);
+  if (err) {
+    if (iteration_err_start >= MAX_RETRIES) return ERROR;
+    iteration_err_start++;
+    return REPEAT;
+  }
+  iteration_err_start = 0;
   PrintFreeRAM();
   StaticJsonBuffer<BUF_LENGTH_MEDIUM> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
@@ -313,10 +320,13 @@ int HeartbeatFunc(unsigned long state_start_time, int num_iterations_in_state) {
   err = root[ERROR_STATUS_FIELD];
   if (err) return ERROR;
   short is_active = root[IS_ACTIVE_FIELD];
-  if (!is_active) return TIMEOUT;
+  if (!is_active) {
+    SetEEPROMDataNoParty();
+    return TIMEOUT;
+  }
   short buzz = root[BUZZ_FIELD];
   if (buzz) return SUCCESS;
-  wait_time = root[PARTY_WAIT_TIME_FIELD];
+  // wait_time = root[PARTY_WAIT_TIME_FIELD];
   return REPEAT;
 }
 
@@ -333,10 +343,10 @@ int AcceptAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_s
   char rep_buf[BUF_LENGTH_SMALL];
   FlashStrPtr json_skeleton = F("{\""BUZZER_NAME_FIELD"\":\"%s\",\""PARTY_ID_FIELD"\":%d}");
   // calculate the number of digits in the current party_id
-  int num_digits = NUM_DIGITS(party_id);
+  int num_digits = NUM_DIGITS(eeprom_data.curr_party_id);
   // -4 is because the string format specifiers won't actually be in the final char buf.
-  char post_data[strlen_P((prog_char *)json_skeleton)+strlen(buzzer_name_global)+num_digits+1];
-  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, buzzer_name_global, party_id);
+  char post_data[strlen_P((prog_char *)json_skeleton)+strlen(eeprom_data.buzzer_name)+num_digits+1];
+  snprintf_P(post_data, sizeof(post_data), (prog_char *)json_skeleton, eeprom_data.buzzer_name, eeprom_data.curr_party_id);
   short err;
   err = fona_shield.HTTPPOSTOneLine(F("http://restaur-anteater.herokuapp.com/buzzer_api/accept_party"), post_data, sizeof(post_data), rep_buf, sizeof(rep_buf));
   if (err) return (num_iterations_in_state < MAX_RETRIES) ? REPEAT : ERROR;
@@ -344,6 +354,8 @@ int AcceptAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_s
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
   err = root[ERROR_STATUS_FIELD];
   if (err) return (num_iterations_in_state < MAX_RETRIES) ? REPEAT : ERROR;
+  // write the active party to the EEPROM
+  EEPROMWrite(&eeprom_data);
   return SUCCESS;
 }
 
@@ -370,10 +382,10 @@ int GetAvailPartyFunc(unsigned long state_start_time, int num_iterations_in_stat
   if (root[ERROR_STATUS_FIELD]) return (num_iterations_in_state < MAX_RETRIES) ? REPEAT : ERROR;
   bool party_avail = root[PARTY_AVAIL_FIELD];
   if (party_avail){
-    wait_time = root[PARTY_WAIT_TIME_FIELD];
-    party_id = root[PARTY_ID_FIELD];
-    strncpy(party_name, root[PARTY_NAME_FIELD], sizeof(party_name)-1);
-    party_name[sizeof(party_name)-1] = '\0';
+    eeprom_data.wait_time = root[PARTY_WAIT_TIME_FIELD];
+    eeprom_data.curr_party_id = root[PARTY_ID_FIELD];
+    strncpy(eeprom_data.party_name, root[PARTY_NAME_FIELD], sizeof(eeprom_data.party_name));
+    // eeprom_data.party_name[sizeof(eeprparty_name)-1] = '\0';
     return SUCCESS;
   }
   oled.clear();
@@ -424,7 +436,7 @@ int WaitBuzzerRegFunc(unsigned long state_start_time, int num_iterations_in_stat
   OLED_PRINTLN_FLASH("Please register");
   OLED_PRINTLN_FLASH("buzzer.");
   OLED_PRINTLN_FLASH("Buzzer name: ");
-  oled.println(buzzer_name_global);
+  oled.println(eeprom_data.buzzer_name);
   bool is_buzzer_registered;
   if (IsBuzzerRegistered(&is_buzzer_registered) == ERROR)
     return (num_iterations_in_state < MAX_RETRIES) ? REPEAT : ERROR;
@@ -457,6 +469,8 @@ int FatalErrorFunc(unsigned long state_start_time, int num_iterations_in_state) 
   OLED_PRINTLN_FLASH("Fatal error occured.");
   OLED_PRINTLN_FLASH("Restarting buzzer in\n10 seconds.");
   delay(10000);
+  digitalWrite(ARDUINO_RST_PIN, LOW);
+  // This should never happen.
   return SUCCESS;
 }
 
@@ -486,8 +500,15 @@ int BuzzFunc(unsigned long state_start_time, int num_iterations_in_state) {
   StaticJsonBuffer<BUF_LENGTH_MEDIUM> jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject(rep_buf);
   err = root[ERROR_STATUS_FIELD];
-  if (err) return ERROR;
+  if (err) {
+    if (iteration_err_start >= MAX_RETRIES) return ERROR;
+    iteration_err_start++;
+    return REPEAT;
+  }
   short is_active = root[IS_ACTIVE_FIELD];
-  if (!is_active) return SUCCESS;
+  if (!is_active) {
+    SetEEPROMDataNoParty();
+    return SUCCESS;
+  }
   return REPEAT;
 }

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -24,6 +24,8 @@
 #define ERROR_STATUS_FIELD "e"
 #define ERROR_MESSAGE_FIELD "e_msg"
 
+static int iteration_err_start = 0;
+
 int InitFunc(unsigned long state_start_time, int num_iterations_in_state);
 int BuzzFunc(unsigned long state_start_time, int num_iterations_in_state);
 int InitFonaShieldFunc(unsigned long state_start_time, int num_iterations_in_state);

--- a/buzzer/EEPROMReadWrite.h
+++ b/buzzer/EEPROMReadWrite.h
@@ -64,16 +64,12 @@ inline bool EEPROMRead(char *buf, int buf_len) {
   return true;
 }
 
-inline void EEPROMWriteCurrPartyID(int curr_party_id) {
-  EEPROM.write(BASE_ADDRESS+LONGEST_BUZZER_NAME+1, curr_party_id);
-}
-
+/*
+ * Writes the EEPROMData struct to the EEPROM.
+*/
 
 inline void EEPROMWrite(EEPROMData *data) {
   EEPROM.put(BASE_ADDRESS, *data);
 }
-
-
-
 
 #endif

--- a/buzzer/EEPROMReadWrite.h
+++ b/buzzer/EEPROMReadWrite.h
@@ -12,6 +12,18 @@
 #include <EEPROM.h>
 #include <Arduino.h>
 
+#define LONGEST_BUZZER_NAME 26
+#define BASE_ADDRESS 0
+#define LONGEST_PARTY_NAME 20
+
+struct EEPROMData {
+  char buzzer_name[LONGEST_BUZZER_NAME+1];
+  int curr_party_id;
+  short wait_time;
+  // party names received from the API calls are truncated at 20 characters.
+  char party_name[LONGEST_PARTY_NAME+1];
+};
+
 /*
  * Writes the given char buf to the EEPROM starting at address 0.
  *
@@ -23,7 +35,7 @@
  * @return false if there was a problem (buffer length longer than EEPROM size), true otherwise.
 */
 
-inline bool EEPROMWrite(const char *buf, int buf_len) {
+inline bool EEPROMWriteBuzzerName(const char *buf, int buf_len) {
   if (buf_len > EEPROM.length()) return false;
   int addr = 0;
   while(addr < buf_len) {
@@ -51,5 +63,17 @@ inline bool EEPROMRead(char *buf, int buf_len) {
   }
   return true;
 }
+
+inline void EEPROMWriteCurrPartyID(int curr_party_id) {
+  EEPROM.write(BASE_ADDRESS+LONGEST_BUZZER_NAME+1, curr_party_id);
+}
+
+
+inline void EEPROMWrite(EEPROMData *data) {
+  EEPROM.put(BASE_ADDRESS, *data);
+}
+
+
+
 
 #endif

--- a/buzzer/FonaShield.cpp
+++ b/buzzer/FonaShield.cpp
@@ -124,17 +124,10 @@ int FonaShield::GetOneLineHTTPRes(char *http_res_buffer, int http_res_buffer_len
     if (elapsed_time > HTTP_TIMEOUT) return TIMEOUT;
   }
   int status = getHTTPStatusFromRes(at_res_buffer);
-  if (status != 200) {
-    Serial.println("status fail");
-    return HTTPFail();
-  }
+  if (status != 200) return HTTPFail();
   sendATCommand(F("AT+HTTPREAD"));
   readAvailBytesFromSerial(at_res_buffer, sizeof(at_res_buffer), 1000);
-  if (!getOneLineHTTPReplyFromRes(at_res_buffer, sizeof(at_res_buffer), http_res_buffer, http_res_buffer_len)) {
-    Serial.println("failed at getOneLineHTTPReplyFromRes");
-    return HTTPFail();
-  }
-  Serial.println("didn't fail");
+  if (!getOneLineHTTPReplyFromRes(at_res_buffer, sizeof(at_res_buffer), http_res_buffer, http_res_buffer_len)) return HTTPFail();
   return SUCCESS;
 }
 

--- a/buzzer/Globals.h
+++ b/buzzer/Globals.h
@@ -14,27 +14,23 @@
 #include "FonaShield.h"
 #include "SSD1306Ascii.h"
 #include "SSD1306AsciiAvrI2c.h"
-
-extern BuzzerFSM buzzer_fsm;
-extern SoftwareSerial fona_serial;
-extern FonaShield fona_shield;
-extern SSD1306AsciiAvrI2c oled;
-enum ret_vals {SUCCESS, ERROR, REPEAT, TIMEOUT};
-// longest length of buzzer name should be around this
-extern char buzzer_name_global[30];
-extern int party_id;
-extern short wait_time;
-// party names received from the API calls are truncated at 20 characters.
-extern char party_name[20];
-extern short batt_percentage;
-extern bool has_system_been_initialized;
-extern unsigned long button_press_start;
-extern bool usb_cabled_plugged_in;
+#include "EEPROMReadWrite.h"
 
 #define MAX_RETRIES 10
 #define BUF_LENGTH_LARGE 90
 #define BUF_LENGTH_MEDIUM 64
 #define BUF_LENGTH_SMALL 32
 #define NO_PARTY -1
+
+extern BuzzerFSM buzzer_fsm;
+extern SoftwareSerial fona_serial;
+extern FonaShield fona_shield;
+extern SSD1306AsciiAvrI2c oled;
+enum ret_vals {SUCCESS, ERROR, REPEAT, TIMEOUT};
+extern EEPROMData eeprom_data;
+extern short batt_percentage;
+extern bool has_system_been_initialized;
+extern unsigned long button_press_start;
+extern bool usb_cabled_plugged_in;
 
 #endif

--- a/buzzer/Pins.h
+++ b/buzzer/Pins.h
@@ -3,7 +3,7 @@
   Pins.h
 
   Description:
-  Defines for the various peripheral pins. 
+  Defines for the various peripheral pins.
  */
 
 #ifndef PINS_H
@@ -14,6 +14,7 @@
 #define FONA_TX_PIN 3
 #define FONA_RST_PIN 4
 #define BUTTON_PIN 8
+#define ARDUINO_RST_PIN 10
 // 0X3C+SA0 - 0x3C or 0x3D
 #define I2C_ADDRESS 0x3D
 #define OLED_RST 9

--- a/buzzer/buzzer.ino
+++ b/buzzer/buzzer.ino
@@ -164,14 +164,14 @@ void loop() {
   }
 
   // Poke the FSM if the the USB cable has been plugged in or unplugged.
-  // if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = true;
-  //   buzzer_fsm.USBCablePluggedIn();
-  // }
-  // if (readVcc() < 4300 && usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = false;
-  //   buzzer_fsm.USBCableUnplugged();
-  // }
+  if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = true;
+    buzzer_fsm.USBCablePluggedIn();
+  }
+  if (readVcc() < 4300 && usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = false;
+    buzzer_fsm.USBCableUnplugged();
+  }
 
   // Record the start time of a button press.
   if (digitalRead(BUTTON_PIN) == LOW && button_press_start == 0) button_press_start = millis();


### PR DESCRIPTION
The Buzzer now recovers from a crash if it was active at the time it crashed.

Data written to the EEPROM is now stored in a struct (current party ID, current party name, wait time, buzzer name). When a new party is accepted, the relevant party data is written to the EEPROM. When the Buzzer starts up it looks to see if there is valid data in the EEPROM, and if there is it goes straight to the `HEARTBEAT` state after initializing everything and resumes displaying the party data. We could have gotten away with just storing the current party ID in the EEPROM and making an API call to figure out the party name and wait time but for now I figured it was better to write more data to the EEPROM than have another external API call.