### PR TITLE
Big PR

### DIFF
--- a/buzzer/BuzzerFSM.cpp
+++ b/buzzer/BuzzerFSM.cpp
@@ -113,6 +113,10 @@ void BuzzerFSM::ForceState(int new_state_id) {
   _curr_state_id = new_state_id;
 }
 
+void BuzzerFSM::LowCellReception() {
+  if (_curr_state_id == IDLE || _curr_state_id == HEARTBEAT) ForceState(LOW_CELL_RECEPTION);
+}
+
 /*
  * Adds a state to the FSM.
  *

--- a/buzzer/BuzzerFSM.cpp
+++ b/buzzer/BuzzerFSM.cpp
@@ -113,6 +113,13 @@ void BuzzerFSM::ForceState(int new_state_id) {
   _curr_state_id = new_state_id;
 }
 
+/*
+ * Called by loop() in buzzer.ino when low cell reception has been detected.
+ *
+ * If the FSM is in the IDLE or HEARTBEAT state, this forces a transition to the LOW_CELL_RECEPTION
+ * state.
+*/
+
 void BuzzerFSM::LowCellReception() {
   if (_curr_state_id == IDLE || _curr_state_id == HEARTBEAT) ForceState(LOW_CELL_RECEPTION);
 }

--- a/buzzer/BuzzerFSM.h
+++ b/buzzer/BuzzerFSM.h
@@ -26,7 +26,7 @@ struct State {
 // enum that contains all the possible state IDs.
 enum state_ids {INIT, INIT_FONA, INIT_GPRS, GET_BUZZER_NAME, IDLE, CHECK_BUZZER_REGISTRATION,
                 WAIT_BUZZER_REGISTRATION, GET_AVAILABLE_PARTY, ACCEPT_AVAILABLE_PARTY, HEARTBEAT,
-                BUZZ, CHARGING, SHUTDOWN, SLEEP, FATAL_ERROR, WAKEUP};
+                BUZZ, CHARGING, SHUTDOWN, SLEEP, FATAL_ERROR, LOW_CELL_RECEPTION, WAKEUP};
 
 // _state_start_time is set to this after a state has been
 // transitioned to. This is not a private class variable to save space.
@@ -50,6 +50,7 @@ class BuzzerFSM {
     void LongButtonPress();
     void USBCablePluggedIn();
     void USBCableUnplugged();
+    void LowCellReception();
     BuzzerFSM(State initial_state, int initial_state_id);
     BuzzerFSM(){};
 };

--- a/buzzer/BuzzerFSM.h
+++ b/buzzer/BuzzerFSM.h
@@ -39,7 +39,7 @@ class BuzzerFSM {
     unsigned long _state_start_time = 0;
     int _num_iterations_in_state = 0;
     int _curr_state_id;
-    State _states[WAKEUP];
+    State _states[WAKEUP+1];
     int DoState();
     void TransitionToNextState(int do_state_ret_val);
     void ForceState(int new_state_id);

--- a/buzzer/BuzzerFSMCallbacks.cpp
+++ b/buzzer/BuzzerFSMCallbacks.cpp
@@ -481,6 +481,24 @@ int FatalErrorFunc(unsigned long state_start_time, int num_iterations_in_state) 
   return SUCCESS;
 }
 
+int LowCellReceptionFunc(unsigned long state_start_time, int num_iterations_in_state) {
+  oled.clear();
+  analogWrite(BUZZER_PIN, 255);
+  delay(300);
+  analogWrite(BUZZER_PIN, 0);
+  delay(300);
+  analogWrite(BUZZER_PIN, 255);
+  delay(300);
+  analogWrite(BUZZER_PIN, 0);
+  OLED_PRINTLN_FLASH("Low cell reception\n");
+  while (fona_shield.GetRSSIVal() < LOW_SIGNAL_THRESHOLD) {
+    delay(1000);
+    return REPEAT;
+  }
+  if (eeprom_data.curr_party_id != NO_PARTY) return SUCCESS;
+  return ERROR;
+}
+
 /*
  * This state runs when then Buzzer should buzz. It vibrates the motor for 2 seconds then pings the
  * API to see whether or not it should keep buzzing or return to IDLE. This API interaction is

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -24,8 +24,15 @@
 #define ERROR_STATUS_FIELD "e"
 #define ERROR_MESSAGE_FIELD "e_msg"
 
-static int num_iterations_in_error = 0;
 
+// Used in states that are meant to be repeated multiple times without error. This int and the
+// corresponding macro allow a state to keep track of how many times it has errored. If a state
+// doesn't normally repeat and is only meant to be run once before transition, we can just return
+// repeat and check if num_iterations_in_state is greater than MAX_RETRIES. States that are meant to
+// be run more than once can't do that, hence this int and macro. This is a little janky as this
+// probably should be something that BuzzerFSM handles but I elected to do this as a band-aid as
+// to not add additional complications to BuzzerFSM when only a few states need to use this.
+static int num_iterations_in_error = 0;
 #define CHECK_ERR_IN_INTERATION(err, val_when_err) \
   if (err == val_when_err) { \
       if (num_iterations_in_error >= MAX_RETRIES) return ERROR; \

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -24,7 +24,15 @@
 #define ERROR_STATUS_FIELD "e"
 #define ERROR_MESSAGE_FIELD "e_msg"
 
-static int iteration_err_start = 0;
+static int num_iterations_in_error = 0;
+
+#define CHECK_ERR_IN_INTERATION(err, val_when_err) \
+  if (err == val_when_err) { \
+      if (num_iterations_in_error >= MAX_RETRIES) return ERROR; \
+      num_iterations_in_error++; \
+      return REPEAT; \
+  } \
+  num_iterations_in_error = 0; \
 
 int InitFunc(unsigned long state_start_time, int num_iterations_in_state);
 int BuzzFunc(unsigned long state_start_time, int num_iterations_in_state);

--- a/buzzer/BuzzerFSMCallbacks.h
+++ b/buzzer/BuzzerFSMCallbacks.h
@@ -44,6 +44,7 @@ int SleepFunc(unsigned long state_start_time, int num_iterations_in_state);
 int WakeupFunc(unsigned long state_start_time, int num_iterations_in_state);
 int ChargeFunc(unsigned long state_start_time, int num_iterations_in_state);
 int FatalErrorFunc(unsigned long state_start_time, int num_iterations_in_state);
+int LowCellReceptionFunc(unsigned long state_start_time, int num_iterations_in_state);
 static void UpdateBatteryPercentage(int row, int num_iterations_in_state);
 
 #endif

--- a/buzzer/FonaShield.cpp
+++ b/buzzer/FonaShield.cpp
@@ -100,6 +100,24 @@ int FonaShield::GetBatteryVoltage() {
 }
 
 /*
+*/
+
+int FonaShield::GetRSSIVal() {
+  char csq_res_buf[BUF_LENGTH_SMALL];
+  sendATCommand(F("AT+CSQ"));
+  if (!readAvailBytesFromSerial(csq_res_buf, sizeof(csq_res_buf), 500)) return -1;
+  if (csq_res_buf == NULL) return -1;
+  char *rssi_ptr = strchr(csq_res_buf, ':');
+  if (rssi_ptr == NULL) return -1;
+  // Advance from the : to the actual number (format: CSQ: RSSI, BER)
+  rssi_ptr += 2;
+  char *rssi_end_ptr = strchr(csq_res_buf, ',');
+  if (rssi_end_ptr == NULL) return -1;
+  *rssi_end_ptr = '\0';
+  return atoi(rssi_ptr);
+}
+
+/*
  * Fills the given char buf with one line of an HTTP response. It is assumed that an HTTP request
  * of some sort was initiated before this method was called, otherwise all this method will do is
  * eventually return TIMEOUT.

--- a/buzzer/FonaShield.cpp
+++ b/buzzer/FonaShield.cpp
@@ -100,6 +100,10 @@ int FonaShield::GetBatteryVoltage() {
 }
 
 /*
+ * Returns the RSSI (received signal strength indicator, used to measure the strength of a radio
+ * signal) of the cell modem.
+ *
+ * @return the RSSI value of the cell modem, or -1 if something went wrong.
 */
 
 int FonaShield::GetRSSIVal() {

--- a/buzzer/FonaShield.h
+++ b/buzzer/FonaShield.h
@@ -27,7 +27,7 @@
 
 // The default amount of time to wait for new bytes to be received from the cell radio before we
 // assume no new bytes are coming.
-#define AT_TIMEOUT 50
+#define AT_TIMEOUT 100
 
 // Main class that serves as the FONA 800 driver.
 class FonaShield {
@@ -60,6 +60,7 @@ class FonaShield {
     int HTTPPOSTOneLine(FlashStrPtr URL, char *post_data_buffer, int post_data_buffer_len,
                          char *http_res_buffer, int http_res_buffer_len);
     int GetBatteryVoltage();
+    int GetRSSIVal();
 };
 
 #endif

--- a/buzzer/Globals.h
+++ b/buzzer/Globals.h
@@ -21,6 +21,7 @@
 #define BUF_LENGTH_MEDIUM 64
 #define BUF_LENGTH_SMALL 32
 #define NO_PARTY -1
+#define LOW_SIGNAL_THRESHOLD 5
 
 extern BuzzerFSM buzzer_fsm;
 extern SoftwareSerial fona_serial;

--- a/buzzer/Helpers.h
+++ b/buzzer/Helpers.h
@@ -22,8 +22,6 @@
 #define OLED_PRINTLN_FLASH(str) oled.println(F(str))
 #define OLED_PRINT_FLASH(str) oled.print(F(str))
 
-#define NUM_DIGITS(num) floor(log10(abs(num))) + 1
-
 #define NUM_DIGITS(x) ((x == 0) ? 1 : floor(log10(abs(x))) + 1)
 
 typedef char PROGMEM prog_char;

--- a/buzzer/Pins.h
+++ b/buzzer/Pins.h
@@ -9,10 +9,25 @@
 #ifndef PINS_H
 #define PINS_H
 
+#include "Version.h"
+
+
+#if BOARD_TYPE == V2 || BOARD_TYPE == V1
+  #define BUTTON_LOGIC_HIGH LOW
+  #define BUTTON_LOGIC_LOW HIGH
+#elif BOARD_TYPE == JANKBOARD
+  #define BUTTON_LOGIC_HIGH HIGH
+  #define BUTTON_LOGIC_LOW LOW
+#endif
+
 #define BUZZER_PIN 6
 #define FONA_RX_PIN 12
 #define FONA_TX_PIN 3
-#define FONA_RST_PIN 4
+
+#if BOARD_TYPE == V2 || BOARD_TYPE == V1
+  #define FONA_RST_PIN 13
+#endif
+
 #define BUTTON_PIN 8
 #define ARDUINO_RST_PIN 10
 // 0X3C+SA0 - 0x3C or 0x3D

--- a/buzzer/Version.h
+++ b/buzzer/Version.h
@@ -1,0 +1,16 @@
+/*
+  File:
+  Version.h
+
+  Description:
+  Provides a way to change the build for various versions of PCBs.
+ */
+
+#ifndef VERSION_H
+#define VERSION_H
+
+enum pcb_versions {V1, V2, JANKBOARD};
+
+#define BOARD_TYPE V2
+
+#endif

--- a/buzzer/buzzer.ino
+++ b/buzzer/buzzer.ino
@@ -55,6 +55,7 @@ void init_fsm() {
   buzzer_fsm.AddState({IDLE, FATAL_ERROR, FATAL_ERROR, SleepFunc}, SLEEP);
   buzzer_fsm.AddState({IDLE, FATAL_ERROR, FATAL_ERROR, ChargeFunc}, CHARGING);
   buzzer_fsm.AddState({INIT, INIT, INIT, FatalErrorFunc}, FATAL_ERROR);
+  buzzer_fsm.AddState({HEARTBEAT, IDLE, FATAL_ERROR, LowCellReceptionFunc}, LOW_CELL_RECEPTION);
 }
 
 /*
@@ -164,14 +165,18 @@ void loop() {
   }
 
   // Poke the FSM if the the USB cable has been plugged in or unplugged.
-  if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
-    usb_cabled_plugged_in = true;
-    buzzer_fsm.USBCablePluggedIn();
-  }
-  if (readVcc() < 4300 && usb_cabled_plugged_in) {
-    usb_cabled_plugged_in = false;
-    buzzer_fsm.USBCableUnplugged();
-  }
+  // if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
+  //   usb_cabled_plugged_in = true;
+  //   buzzer_fsm.USBCablePluggedIn();
+  // }
+  // if (readVcc() < 4300 && usb_cabled_plugged_in) {
+  //   usb_cabled_plugged_in = false;
+  //   buzzer_fsm.USBCableUnplugged();
+  // }
+
+  // Poke the FSM if the cell reception gets low. Might not result in a state transition if the FSM
+  // isn't in IDLE or HEARTBEAT
+  if (fona_shield.GetRSSIVal() < LOW_CELL_RECEPTION) buzzer_fsm.LowCellReception();
 
   // Record the start time of a button press.
   if (digitalRead(BUTTON_PIN) == LOW && button_press_start == 0) button_press_start = millis();

--- a/buzzer/buzzer.ino
+++ b/buzzer/buzzer.ino
@@ -15,6 +15,7 @@
 #include "Pins.h"
 #include "EEPROMReadWrite.h"
 #include "LPF.h"
+#include "Version.h"
 
 // Initializations of global variables definied in "Globals.h".
 BuzzerFSM buzzer_fsm({INIT_FONA, INIT, INIT, InitFunc}, INIT);
@@ -55,7 +56,7 @@ void init_fsm() {
   buzzer_fsm.AddState({IDLE, FATAL_ERROR, FATAL_ERROR, SleepFunc}, SLEEP);
   buzzer_fsm.AddState({IDLE, FATAL_ERROR, FATAL_ERROR, ChargeFunc}, CHARGING);
   buzzer_fsm.AddState({INIT, INIT, INIT, FatalErrorFunc}, FATAL_ERROR);
-  buzzer_fsm.AddState({HEARTBEAT, IDLE, FATAL_ERROR, LowCellReceptionFunc}, LOW_CELL_RECEPTION);
+  buzzer_fsm.AddState({HEARTBEAT, FATAL_ERROR, IDLE, LowCellReceptionFunc}, LOW_CELL_RECEPTION);
 }
 
 /*
@@ -64,7 +65,6 @@ void init_fsm() {
 */
 
 void get_buzzer_name_from_eeprom() {
-  // EEPROMRead(eeprom_data.buzzer_name, sizeof(eeprom_data.buzzer_name));
   EEPROM.get(0, eeprom_data);
   DEBUG_PRINTLN_FLASH("Stored in eeprom: ");
   DEBUG_PRINTLN(eeprom_data.buzzer_name);
@@ -86,6 +86,10 @@ void buzz_twice() {
   analogWrite(BUZZER_PIN, 0);
 }
 
+/*
+ * Sets up all the various peripheral pins.
+*/
+
 void setup_pins() {
   digitalWrite(ARDUINO_RST_PIN, HIGH);
   pinMode(LED_BUILTIN, OUTPUT);
@@ -93,8 +97,10 @@ void setup_pins() {
   pinMode(BUTTON_PIN, INPUT);
   pinMode(BUZZER_PIN, OUTPUT);
   pinMode(ARDUINO_RST_PIN, OUTPUT);
+  #if BOARD_TYPE == V1 || BOARD_TYPE == V2
   // enable internal pull up resistor in arduino
   digitalWrite(BUTTON_PIN, HIGH);
+  #endif
 }
 
 /*
@@ -139,7 +145,6 @@ void setup() {
 */
 
 void loop() {
-
   // Do the work of the current FSM state.
   buzzer_fsm.ProcessState();
 
@@ -165,21 +170,22 @@ void loop() {
   }
 
   // Poke the FSM if the the USB cable has been plugged in or unplugged.
-  // if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = true;
-  //   buzzer_fsm.USBCablePluggedIn();
-  // }
-  // if (readVcc() < 4300 && usb_cabled_plugged_in) {
-  //   usb_cabled_plugged_in = false;
-  //   buzzer_fsm.USBCableUnplugged();
-  // }
+  if (readVcc() >= 4300 && !usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = true;
+    buzzer_fsm.USBCablePluggedIn();
+  }
+  if (readVcc() < 4300 && usb_cabled_plugged_in) {
+    usb_cabled_plugged_in = false;
+    buzzer_fsm.USBCableUnplugged();
+  }
 
   // Poke the FSM if the cell reception gets low. Might not result in a state transition if the FSM
   // isn't in IDLE or HEARTBEAT
-  if (fona_shield.GetRSSIVal() < LOW_CELL_RECEPTION) buzzer_fsm.LowCellReception();
+  int rssi_val = fona_shield.GetRSSIVal();
+  if (rssi_val != -1 && rssi_val < LOW_SIGNAL_THRESHOLD) buzzer_fsm.LowCellReception();
 
   // Record the start time of a button press.
-  if (digitalRead(BUTTON_PIN) == LOW && button_press_start == 0) button_press_start = millis();
+  if (digitalRead(BUTTON_PIN) == BUTTON_LOGIC_HIGH && button_press_start == 0) button_press_start = millis();
 
   // If a button press duration is longer than 5 seconds (5000 ms), poke the FSM.
   if (button_press_start != 0) {
@@ -192,7 +198,7 @@ void loop() {
   }
 
   // If it was a short button press and the button has now been released, poke the FSM.
-  if (digitalRead(BUTTON_PIN) == HIGH && button_press_start != 0) {
+  if (digitalRead(BUTTON_PIN) == BUTTON_LOGIC_LOW && button_press_start != 0) {
     unsigned long button_press_duration = get_button_press_duration(button_press_start);
     if (button_press_duration > 0 && button_press_duration < 5000) {
       DEBUG_PRINTLN_FLASH("Short button press registered.");


### PR DESCRIPTION
This PR does a lot of things.

- Fixes a long standing buffer overrun where the array that contains all the BuzzerFSM states was 1 state too small. This has been in place since early last term so I have no idea how this was never caught sooner, might have explained some of the phantom problems we were seeing.

- Fixes problems with the cell modem that we were seeing. When we changed from the solderless breadboard to the PCBs, there was a pin change with the reset pin for the cell modem which was never changed in `Pins.h` so the reset pin was dangling. Probably explains why we were seeing cell modems randomly reset.

- Introduces conditional compilation (used for the pins, button logic levels) for different versions of PCBs.

- Gets rid of the expected wait time from the HEARTBEAT display. https://github.com/jfeiber/buzzer-embedded/issues/31

- Introduces a warning when the Buzzer is taken out of cell range. FSM only transitions to this state if the Buzzer is currently in IDLE or HEARTBEAT. https://github.com/jfeiber/buzzer-embedded/issues/32

-  Cleans up and centralizes the code that is used by states that normally repeat to keep track of how many times the state has errored. Fixes a problem in `BuzzFunc`.